### PR TITLE
Gettting a NoContent (204) response is not an error

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -194,7 +194,7 @@ func (r *Repo) Update(q string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		b, err := ioutil.ReadAll(resp.Body)
 		var msg string
 		if err != nil {


### PR DESCRIPTION
When calling the Update method

err = repo.Update(myinsert)

I get an error back even though everything works fine (the data I insert are actually inserted). The response from the server is a NoContent response (https://httpstatuses.com/204) which is not really an error. There is just no information to send back. The code however see all responses that are different from 200 as an error.

I am connecting to GraphDB (http://graphdb.ontotext.com/).
