### PR TITLE
Enabling support for ASK queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cem-okulmus/sparql
+module github.com/knakk/sparql
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knakk/sparql
+module github.com/cem-okulmus/sparql
 
 go 1.18
 

--- a/sparql.go
+++ b/sparql.go
@@ -25,6 +25,7 @@ func init() {
 // Results holds the parsed results of a application/sparql-results+json response.
 type Results struct {
 	Head    header
+	Boolean bool
 	Results results
 }
 


### PR DESCRIPTION
As discussed in #20 , this pull-request would enable knack/sparql to also get results back for SPARQL queries that use the ASK keyword.
Given the simplicity of the change, I think it's safe to say that it does not introduce any (new) bugs. 