### PR TITLE
Preserving datatype for "literal" values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cem-okulmus/sparql
+module github.com/knakk/sparql
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knakk/sparql
+module github.com/cem-okulmus/sparql
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knack/sparql
+module github.com/knakk/sparql
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cem-okulmus/sparql
+module github.com/knack/sparql
 
 go 1.18
 

--- a/sparql.go
+++ b/sparql.go
@@ -105,6 +105,10 @@ func termFromJSON(b binding) (rdf.Term, error) {
 		if b.Lang != "" {
 			return rdf.NewLangLiteral(b.Value, b.Lang)
 		}
+		if b.DataType != "" {
+			dt, _ := rdf.NewIRI(b.DataType)
+			return rdf.NewTypedLiteral(b.Value, dt), nil
+		}
 		return rdf.NewTypedLiteral(b.Value, xsdString), nil
 	case "typed-literal":
 		iri, err := rdf.NewIRI(b.DataType)

--- a/sparql.go
+++ b/sparql.go
@@ -25,6 +25,7 @@ func init() {
 // Results holds the parsed results of a application/sparql-results+json response.
 type Results struct {
 	Head    header
+	Boolean bool
 	Results results
 }
 


### PR DESCRIPTION
As discussed in #25, this PR would change the behaviour when encountering values with type "literal". Instead of always using the datatype xsd:string, the code here checks first whether the returned datatype is different from nil, and if so, keeps this returned datatype.  
